### PR TITLE
Fix: Like Button Not Aligned

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,6 @@ body {
 button {
   font-size: 22px;
   padding: 20px;
-  margin: 50px;
   position: absolute;
   bottom: 0;
   right: 0;
@@ -255,6 +254,7 @@ footer {
 }
 
 .row {
+  position: relative;
   display: flex;
   gap: 75px;
   flex: 0 0 825px;

--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
             </li>
           </ul>
         </aside>
+        <button>❤️ Like</button>
       </div>
 
       <footer>
@@ -140,6 +141,5 @@
       </footer>
     </div>
 
-    <button>❤️ Like</button>
   </body>
 </html>


### PR DESCRIPTION
I fixed the "Like Button Not Aligned" issue by aligning the button to the bottom right of the "row".